### PR TITLE
add a command to list names of clusters

### DIFF
--- a/i2ssh/config.py
+++ b/i2ssh/config.py
@@ -20,5 +20,10 @@ class Config:
         if not name in self._cfg:
             logging.error('%s is not a cluster in %s', args.cluster, config_path)
             sys.exit(0)
+
         return self._cfg[name]
+
+    def clusternames(self):
+        """Return the names of the clusters in the config file"""
+        return self._cfg.keys()
 

--- a/i2ssh/main.py
+++ b/i2ssh/main.py
@@ -13,8 +13,9 @@ DEFAULT_CONFIG = '~/.i2sshrc'
 
 def main():
     parser = argparse.ArgumentParser()
+
     parser.add_argument(
-            'cluster',
+            'cluster', nargs='?',
             help='the cluster to connect to.')
     parser.add_argument(
             '-c', '--config', default=DEFAULT_CONFIG,
@@ -22,12 +23,29 @@ def main():
     parser.add_argument(
            '-v', '--verbose', action='store_true', default=False,
             help='increases log verbosity.')
+    parser.add_argument(
+            '-l', '--list', action='store_true', default=False,
+            help='list the clusters in the config file.')
     args = parser.parse_args()
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
 
-    config = Config(path=args.config).cluster(args.cluster)
+    config = Config(path=args.config)
+
+    if args.list:
+        print "Clusters in %s:" % (args.config)
+        for name in config.clusternames():
+            print "- %s" % (name)
+        return
+
+    # need to check if this is set manually due to use of nargs=? above, which
+    # seems to be only way to get an optional arg list --list to work and not
+    # also require the cluster positional arg to be set
+    if args.cluster is None:
+        parser.error("cluster name is required")
+
+    config = config.cluster(args.cluster)
     logging.debug('Cluster config: %s', config)
 
     layout = Layout(config)


### PR DESCRIPTION
Adds a `--list` or `-l` optional argument which can list the names of
the clusters in the config file.

This might be useful if you are the type of person like me who often
forgets the name of the clusters in his config file and gets tired of
opening the config file up.
